### PR TITLE
Fix JournalForm date default

### DIFF
--- a/forms.py
+++ b/forms.py
@@ -208,7 +208,7 @@ class QuickTradeForm(FlaskForm):
     submit = SubmitField('Add Trade')
 
 class JournalForm(FlaskForm):
-    journal_date = DateField('Date', validators=[DataRequired()], default=datetime.now().date())
+    journal_date = DateField('Date', validators=[DataRequired()], default=date.today)
     daily_pnl = FloatField('Daily P&L ($)', validators=[Optional()],
                           render_kw={"step": "0.01", "placeholder": "Total P&L for the day"})
     


### PR DESCRIPTION
## Summary
- default to `date.today` for JournalForm's date field

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement Flask==3.0.3)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_683fd58203348333a29f8ebda9b2cde8