### PR TITLE
Fix env filename in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ A comprehensive trading platform that combines AI-powered trade analysis with pr
 
 3. **Set up environment variables**
    ```bash
-   cp env.example .env
+   cp env_example.txt .env
    # Edit .env with your configuration
    ```
 


### PR DESCRIPTION
## Summary
- fix env file name in README setup instructions

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_683fd6017cc88333ac06772799b25281