### PR TITLE
Add Tradier token config

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,9 @@ DATABASE_URL=sqlite:///app.db
 # OpenAI API (for AI analysis)
 OPENAI_API_KEY=your-openai-api-key
 
+# Tradier Configuration
+TRADIER_API_TOKEN=your-tradier-token
+
 # Email Configuration (optional)
 MAIL_SERVER=smtp.gmail.com
 MAIL_PORT=587

--- a/TRADIER_SETUP.md
+++ b/TRADIER_SETUP.md
@@ -32,6 +32,9 @@ export TRADIER_API_TOKEN=your_actual_token_here
 python app.py
 ```
 
+The application reads this value from the `TRADIER_API_TOKEN` environment
+variable (see `config.py`).
+
 ### Option B: Direct Code Modification
 Edit `app.py` and replace:
 ```python

--- a/config.py
+++ b/config.py
@@ -7,6 +7,9 @@ class Config:
     
     # OpenAI Configuration
     OPENAI_API_KEY = os.environ.get('OPENAI_API_KEY')
+
+    # Tradier Configuration
+    TRADIER_API_TOKEN = os.environ.get('TRADIER_API_TOKEN')
     
     # Mail Configuration (for user registration/password reset)
     MAIL_SERVER = os.environ.get('MAIL_SERVER') or 'smtp.gmail.com'

--- a/env_example.txt
+++ b/env_example.txt
@@ -1,0 +1,3 @@
+# Example environment variables
+TRADIER_API_TOKEN=your-tradier-token
+


### PR DESCRIPTION
## Summary
- add `TRADIER_API_TOKEN` in `config.py`
- document `TRADIER_API_TOKEN` environment variable in README and setup guide
- provide example in `env_example.txt`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_683fd68edf7083338281f4d604125a73