### PR TITLE
Add tabbed PnL scenarios

### DIFF
--- a/templates/pnl_modal.html
+++ b/templates/pnl_modal.html
@@ -21,29 +21,43 @@
                         <button id="showPercent" type="button" class="btn btn-outline-secondary">Percent</button>
                     </div>
                 </div>
-                <div class="chart-container mb-3" style="position: relative; height: 400px;">
-                    <canvas id="pnlChart"></canvas>
-                </div>
-                <div id="zoomControls" class="mb-3">
-                    <button id="zoomIn" class="btn btn-sm btn-outline-primary">Zoom In</button>
-                    <button id="zoomOut" class="btn btn-sm btn-outline-primary">Zoom Out</button>
-                    <button id="resetZoom" class="btn btn-sm btn-outline-secondary">Reset Zoom</button>
-                    <span class="text-muted ms-3"><small>Use mouse wheel to zoom, Ctrl+drag to pan</small></span>
-                </div>
-                <div class="table-responsive">
-                    <table class="table table-sm" id="pnlDataTable">
-                        <thead class="table-primary">
-                            <tr>
-                                <th>Stock Price</th>
-                                <th id="timeHeader0">At Expiration</th>
-                                <th id="timeHeader1">Days Left</th>
-                                <th id="timeHeader2">Days Left</th>
-                                <th id="timeHeader3">Days Left</th>
-                                <th id="timeHeader4">Days Left</th>
-                            </tr>
-                        </thead>
-                        <tbody id="pnlTableBody"></tbody>
-                    </table>
+                <ul class="nav nav-tabs mb-3" id="pnlTabs" role="tablist">
+                    <li class="nav-item" role="presentation">
+                        <button class="nav-link active" id="table-tab" data-bs-toggle="tab" data-bs-target="#tablePane" type="button" role="tab">Table</button>
+                    </li>
+                    <li class="nav-item" role="presentation">
+                        <button class="nav-link" id="chart-tab" data-bs-toggle="tab" data-bs-target="#chartPane" type="button" role="tab">Chart</button>
+                    </li>
+                </ul>
+                <div class="tab-content">
+                    <div class="tab-pane fade show active" id="tablePane" role="tabpanel">
+                        <div class="table-responsive">
+                            <table class="table table-sm" id="pnlDataTable">
+                                <thead class="table-primary">
+                                    <tr>
+                                        <th>Stock Price</th>
+                                        <th id="timeHeader0">At Expiration</th>
+                                        <th id="timeHeader1">Days Left</th>
+                                        <th id="timeHeader2">Days Left</th>
+                                        <th id="timeHeader3">Days Left</th>
+                                        <th id="timeHeader4">Days Left</th>
+                                    </tr>
+                                </thead>
+                                <tbody id="pnlTableBody"></tbody>
+                            </table>
+                        </div>
+                    </div>
+                    <div class="tab-pane fade" id="chartPane" role="tabpanel">
+                        <div class="chart-container mb-3" style="position: relative; height: 400px;">
+                            <canvas id="pnlChart"></canvas>
+                        </div>
+                        <div id="zoomControls" class="mb-3">
+                            <button id="zoomIn" class="btn btn-sm btn-outline-primary">Zoom In</button>
+                            <button id="zoomOut" class="btn btn-sm btn-outline-primary">Zoom Out</button>
+                            <button id="resetZoom" class="btn btn-sm btn-outline-secondary">Reset Zoom</button>
+                            <span class="text-muted ms-3"><small>Use mouse wheel to zoom, Ctrl+drag to pan</small></span>
+                        </div>
+                    </div>
                 </div>
             </div>
         </div>

--- a/templates/tools/options_calculator.html
+++ b/templates/tools/options_calculator.html
@@ -910,14 +910,35 @@ document.addEventListener('DOMContentLoaded', function() {
         const tableBody = document.getElementById('pnlTableBody');
         tableBody.innerHTML = '';
 
+        const values = [];
+        data.pnl_data.forEach(priceData => {
+            priceData.time_data.forEach(tp => {
+                values.push(showDollars ? tp.pnl : tp.return_percent);
+            });
+        });
+        const maxAbs = Math.max(...values.map(v => Math.abs(v)), 1);
+
         data.pnl_data.forEach(priceData => {
             const tr = document.createElement('tr');
             tr.innerHTML = `<td>$${priceData.stock_price}</td>`;
             priceData.time_data.forEach(timePoint => {
                 const value = showDollars ? timePoint.pnl : timePoint.return_percent;
                 const formatted = showDollars ? `$${value}` : `${value}%`;
-                const cls = value >= 0 ? 'text-success' : 'text-danger';
-                tr.innerHTML += `<td class="${cls}">${formatted}</td>`;
+                const cls = value >= 0 ? 'text-success' : (value < 0 ? 'text-danger' : '');
+
+                const intensity = Math.min(1, Math.abs(value) / maxAbs);
+                let bg = 'transparent';
+                if (value > 0) {
+                    bg = `rgba(25,135,84,${0.2 + 0.5 * intensity})`;
+                } else if (value < 0) {
+                    bg = `rgba(220,53,69,${0.2 + 0.5 * intensity})`;
+                }
+
+                const td = document.createElement('td');
+                td.className = cls;
+                td.style.backgroundColor = bg;
+                td.textContent = formatted;
+                tr.appendChild(td);
             });
             tableBody.appendChild(tr);
         });
@@ -971,6 +992,15 @@ document.addEventListener('DOMContentLoaded', function() {
             alert('Error calculating P&L.');
         });
     };
+
+    const pnlTabs = document.getElementById('pnlTabs');
+    if (pnlTabs) {
+        pnlTabs.addEventListener('shown.bs.tab', function(e) {
+            if (e.target.id === 'chart-tab' && pnlChart) {
+                pnlChart.resize();
+            }
+        });
+    }
 });
 
 function addToTrades() {


### PR DESCRIPTION
## Summary
- split PnL modal into chart and table tabs
- color PnL table cells from red (loss) to green (profit)
- resize chart when switching to chart tab

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for requests, dotenv, flask)*

------
https://chatgpt.com/codex/tasks/task_e_6840c4965b4483338a644148ff541e54