### PR TITLE
Allow non-logged users to view trade/journal forms

### DIFF
--- a/templates/add_trade.html
+++ b/templates/add_trade.html
@@ -26,6 +26,12 @@
                 </h5>
             </div>
             <div class="card-body">
+                {% if not current_user.is_authenticated %}
+                <div class="alert alert-info">
+                    <i class="fas fa-info-circle me-2"></i>
+                    Log in or create an account to save this trade.
+                </div>
+                {% endif %}
                 <form method="POST" enctype="multipart/form-data">
                     {{ form.hidden_tag() }}
                     


### PR DESCRIPTION
## Summary
- allow guests to open trade form without login
- require login only on POST
- allow journal add page view without login
- show login reminder on Add Trade page

## Testing
- `pip install -r requirements.txt`
- `pip install scipy`
- `pytest -q` *(fails: OPENAI key and API/db unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_6840c78d8f388333a916aaf37c240fed