### PR TITLE
Improve AI Analysis interface

### DIFF
--- a/templates/bulk_analysis.html
+++ b/templates/bulk_analysis.html
@@ -1,0 +1,60 @@
+{% extends "base.html" %}
+
+{% block title %}AI Bulk Analysis{% endblock %}
+
+{% block content %}
+<div class="container py-5">
+    <div class="text-center mb-5">
+        <h1 class="display-5 fw-bold">
+            <i class="fas fa-robot text-success me-2"></i>
+            Bulk Trade Analysis
+        </h1>
+        <p class="lead text-muted">
+            Quickly analyze multiple trades with AI-powered insights and spot
+            key strengths and weaknesses in your strategy.
+        </p>
+        {% if current_user.is_authenticated %}
+            <a href="#bulk-form" class="btn btn-primary btn-lg">
+                <i class="fas fa-bolt me-2"></i>Run Bulk Analysis
+            </a>
+        {% else %}
+            <a href="{{ url_for('register') }}" class="btn btn-primary btn-lg">
+                <i class="fas fa-user-plus me-2"></i>Create Free Account
+            </a>
+            <a href="{{ url_for('login') }}" class="btn btn-outline-secondary btn-lg ms-2">
+                <i class="fas fa-sign-in-alt me-2"></i>Login
+            </a>
+        {% endif %}
+    </div>
+
+    {% if current_user.is_authenticated %}
+    <div id="bulk-form" class="row justify-content-center">
+        <div class="col-md-8">
+            <div class="card">
+                <div class="card-header text-center">
+                    <h5 class="mb-0">
+                        <i class="fas fa-list me-2"></i>Select Trades to Analyze
+                    </h5>
+                </div>
+                <div class="card-body">
+                    <form method="POST">
+                        {{ form.hidden_tag() }}
+                        <div class="form-check mb-3">
+                            {{ form.analyze_all_unanalyzed(class="form-check-input") }}
+                            {{ form.analyze_all_unanalyzed.label(class="form-check-label") }}
+                            <small class="text-muted">({{ unanalyzed_count }} trades)</small>
+                        </div>
+                        <div class="form-check mb-4">
+                            {{ form.analyze_recent(class="form-check-input") }}
+                            {{ form.analyze_recent.label(class="form-check-label") }}
+                            <small class="text-muted">({{ recent_count }} trades)</small>
+                        </div>
+                        {{ form.submit(class="btn btn-success") }}
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+    {% endif %}
+</div>
+{% endblock %}

--- a/templates/view_trade.html
+++ b/templates/view_trade.html
@@ -448,42 +448,75 @@
                 <h5 class="mb-0">
                     <i class="fas fa-robot text-success me-2"></i>
                     AI Analysis
-                    <span class="badge bg-primary ms-2">Score: {{ analysis.overall_score }}/10</span>
                 </h5>
             </div>
             <div class="card-body">
-                <!-- Analysis content would go here -->
-                <div class="row">
-                    <div class="col-md-6">
-                        <h6 class="text-success">Strengths</h6>
-                        <ul>
-                            {% for strength in analysis.get_strengths() %}
-                                <li>{{ strength }}</li>
-                            {% endfor %}
-                        </ul>
-                    </div>
-                    <div class="col-md-6">
-                        <h6 class="text-warning">Areas for Improvement</h6>
-                        <ul>
-                            {% for weakness in analysis.get_weaknesses() %}
-                                <li>{{ weakness }}</li>
-                            {% endfor %}
-                        </ul>
-                    </div>
-                </div>
-                {% if analysis.get_future_setups() %}
-                <hr>
-                <h6 class="text-primary">Future Setups</h6>
-                <ul>
-                    {% for setup in analysis.get_future_setups() %}
-                        <li>{{ setup }}</li>
-                    {% endfor %}
-                </ul>
+                {% set score_class = 'score-poor' %}
+                {% if analysis.overall_score >= 8 %}
+                    {% set score_class = 'score-excellent' %}
+                {% elif analysis.overall_score >= 6 %}
+                    {% set score_class = 'score-good' %}
+                {% elif analysis.overall_score >= 4 %}
+                    {% set score_class = 'score-average' %}
                 {% endif %}
+
+                <div class="text-center mb-4">
+                    <div class="analysis-score {{ score_class }}">
+                        {{ analysis.overall_score }}
+                    </div>
+                    <small class="text-muted d-block mt-2">Overall Score</small>
+                </div>
+
+                <div class="row">
+                    <div class="col-md-4 mb-3">
+                        <div class="card h-100">
+                            <div class="card-body">
+                                <h6 class="text-success mb-3">
+                                    <i class="fas fa-thumbs-up me-1"></i>Strengths
+                                </h6>
+                                <ul class="list-unstyled mb-0 small">
+                                    {% for strength in analysis.get_strengths() %}
+                                        <li>{{ strength }}</li>
+                                    {% endfor %}
+                                </ul>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="col-md-4 mb-3">
+                        <div class="card h-100">
+                            <div class="card-body">
+                                <h6 class="text-warning mb-3">
+                                    <i class="fas fa-exclamation-circle me-1"></i>Areas for Improvement
+                                </h6>
+                                <ul class="list-unstyled mb-0 small">
+                                    {% for weakness in analysis.get_weaknesses() %}
+                                        <li>{{ weakness }}</li>
+                                    {% endfor %}
+                                </ul>
+                            </div>
+                        </div>
+                    </div>
+                    {% if analysis.get_future_setups() %}
+                    <div class="col-md-4 mb-3">
+                        <div class="card h-100">
+                            <div class="card-body">
+                                <h6 class="text-primary mb-3">
+                                    <i class="fas fa-lightbulb me-1"></i>Future Setups
+                                </h6>
+                                <ul class="list-unstyled mb-0 small">
+                                    {% for setup in analysis.get_future_setups() %}
+                                        <li>{{ setup }}</li>
+                                    {% endfor %}
+                                </ul>
+                            </div>
+                        </div>
+                    </div>
+                    {% endif %}
+                </div>
             </div>
         </div>
-        {% endif %}
     </div>
+        {% endif %}
 
     <!-- Sidebar with Additional Info -->
     <div class="col-lg-4">


### PR DESCRIPTION
## Summary
- create `bulk_analysis.html` landing page with hero section and form
- redesign AI analysis card in `view_trade.html` using gradient score badge and subcards

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for flask and other packages)*

------
https://chatgpt.com/codex/tasks/task_e_6840cd82c0b48333a523ec061cc6c563