### PR TITLE
Fix PnL modal chart scaling

### DIFF
--- a/templates/tools/options_calculator.html
+++ b/templates/tools/options_calculator.html
@@ -876,7 +876,10 @@ document.addEventListener('DOMContentLoaded', function() {
                 interaction: { intersect: false, mode: 'index' },
                 scales: {
                     y: { title: { display: true, text: showDollars ? 'Profit/Loss ($)' : 'Return (%)' } },
-                    x: { title: { display: true, text: 'Stock Price ($)' } }
+                    x: {
+                        type: 'linear',
+                        title: { display: true, text: 'Stock Price ($)' }
+                    }
                 },
                 plugins: {
                     zoom: {


### PR DESCRIPTION
## Summary
- ensure the P&L modal uses a numeric x‑axis

## Testing
- `pytest -q` *(fails: no table and network access)*

------
https://chatgpt.com/codex/tasks/task_e_6840f3a81aa883338da00b6f2286e705