### PR TITLE
Fix PnL table time intervals

### DIFF
--- a/app.py
+++ b/app.py
@@ -1107,23 +1107,9 @@ def calculate_options_pnl():
         days_to_exp = (exp_date - datetime.now().date()).days
         time_to_exp = max(days_to_exp / 365.0, 0.001)  # Avoid division by zero
 
-        # Calculate time intervals based on days to expiration
-        time_points = []
-        if days_to_exp <= 7:
-            # For weekly options, use 1-day intervals
-            time_points = [7, 6, 5, 4, 3, 2, 1, 0]  # Reversed order
-        elif days_to_exp <= 30:
-            # For monthly options, use 5-day intervals
-            time_points = [30, 25, 20, 15, 10, 5, 0]  # Reversed order
-        elif days_to_exp <= 90:
-            # For quarterly options, use 15-day intervals
-            time_points = [90, 75, 60, 45, 30, 15, 0]  # Reversed order
-        else:
-            # For longer-term options, use monthly intervals
-            time_points = [180, 150, 120, 90, 60, 30, 0]  # Reversed order
-
-        # Filter time points to not exceed days to expiration
-        time_points = [t for t in time_points if t <= days_to_exp]
+        # Calculate 5 time points as percentages of days to expiration
+        fractions = [0.0, 0.2, 0.4, 0.6, 0.8]
+        time_points = [max(0, round(days_to_exp * f)) for f in fractions]
 
         # Calculate implied volatility (simplified approximation)
         implied_vol = 0.2  # Default assumption

--- a/templates/pnl_modal.html
+++ b/templates/pnl_modal.html
@@ -36,11 +36,11 @@
                                 <thead class="table-primary">
                                     <tr>
                                         <th>Stock Price</th>
-                                        <th id="timeHeader0">At Expiration</th>
-                                        <th id="timeHeader1">Days Left</th>
-                                        <th id="timeHeader2">Days Left</th>
-                                        <th id="timeHeader3">Days Left</th>
-                                        <th id="timeHeader4">Days Left</th>
+                                        <th id="timeHeader0">At Expiry</th>
+                                        <th id="timeHeader1">Time Left</th>
+                                        <th id="timeHeader2">Time Left</th>
+                                        <th id="timeHeader3">Time Left</th>
+                                        <th id="timeHeader4">Time Left</th>
                                     </tr>
                                 </thead>
                                 <tbody id="pnlTableBody"></tbody>

--- a/templates/tools/options_calculator.html
+++ b/templates/tools/options_calculator.html
@@ -855,7 +855,8 @@ document.addEventListener('DOMContentLoaded', function() {
 
         const datasets = [];
         data.option_info.time_points.forEach((days, index) => {
-            const label = days === 0 ? 'At Expiration' : (days === 1 ? '1 Day Left' : `${days} Days Left`);
+            const percent = data.option_info.days_to_expiration ? Math.round((days / data.option_info.days_to_expiration) * 100) : 0;
+            const label = days === 0 ? 'At Expiry' : `${percent}% Time Left`;
             datasets.push({
                 label: label,
                 data: data.pnl_data.map(point => ({ x: point.stock_price, y: showDollars ? point.time_data[index].pnl : point.time_data[index].return_percent })),
@@ -912,7 +913,14 @@ document.addEventListener('DOMContentLoaded', function() {
     function updateTable(data, showDollars) {
         data.option_info.time_points.forEach((days, index) => {
             const header = document.getElementById(`timeHeader${index}`);
-            if (header) header.textContent = days === 0 ? 'At Expiry' : `${days} Days Left`;
+            if (header) {
+                if (days === 0) {
+                    header.textContent = 'At Expiry';
+                } else {
+                    const pct = data.option_info.days_to_expiration ? Math.round((days / data.option_info.days_to_expiration) * 100) : 0;
+                    header.textContent = `${pct}% Time Left`;
+                }
+            }
         });
 
         const tableBody = document.getElementById('pnlTableBody');


### PR DESCRIPTION
## Summary
- ensure `options-pnl` endpoint always returns five time intervals
- derive time points from percentages of days-to-expiration
- adjust PnL modal header placeholders
- display percentage-based labels in chart and table

## Testing
- `pytest -q` *(fails: ModuleNotFoundError & OperationalError)*

------
https://chatgpt.com/codex/tasks/task_e_6840f90fd04c833390ad62bda10c5685