### PR TITLE
Update PnL time labels

### DIFF
--- a/templates/pnl_modal.html
+++ b/templates/pnl_modal.html
@@ -37,10 +37,10 @@
                                     <tr>
                                         <th>Stock Price</th>
                                         <th id="timeHeader0">At Expiry</th>
-                                        <th id="timeHeader1">Time Left</th>
-                                        <th id="timeHeader2">Time Left</th>
-                                        <th id="timeHeader3">Time Left</th>
-                                        <th id="timeHeader4">Time Left</th>
+                                        <th id="timeHeader1">Days Left</th>
+                                        <th id="timeHeader2">Days Left</th>
+                                        <th id="timeHeader3">Days Left</th>
+                                        <th id="timeHeader4">Days Left</th>
                                     </tr>
                                 </thead>
                                 <tbody id="pnlTableBody"></tbody>

--- a/templates/tools/options_calculator.html
+++ b/templates/tools/options_calculator.html
@@ -855,8 +855,7 @@ document.addEventListener('DOMContentLoaded', function() {
 
         const datasets = [];
         data.option_info.time_points.forEach((days, index) => {
-            const percent = data.option_info.days_to_expiration ? Math.round((days / data.option_info.days_to_expiration) * 100) : 0;
-            const label = days === 0 ? 'At Expiry' : `${percent}% Time Left`;
+            const label = days === 0 ? 'At Expiry' : `${days} Days Left`;
             datasets.push({
                 label: label,
                 data: data.pnl_data.map(point => ({ x: point.stock_price, y: showDollars ? point.time_data[index].pnl : point.time_data[index].return_percent })),
@@ -914,12 +913,7 @@ document.addEventListener('DOMContentLoaded', function() {
         data.option_info.time_points.forEach((days, index) => {
             const header = document.getElementById(`timeHeader${index}`);
             if (header) {
-                if (days === 0) {
-                    header.textContent = 'At Expiry';
-                } else {
-                    const pct = data.option_info.days_to_expiration ? Math.round((days / data.option_info.days_to_expiration) * 100) : 0;
-                    header.textContent = `${pct}% Time Left`;
-                }
+                header.textContent = days === 0 ? 'At Expiry' : `${days} Days Left`;
             }
         });
 


### PR DESCRIPTION
## Summary
- change PnL modal headers to show `Days Left`
- use days directly for PnL table headers
- show matching labels for chart datasets

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_68410bbde33c8333ae4daeb0892eab31