### PR TITLE
Add options PnL endpoint test and CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,23 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install scipy
+      - name: Run tests
+        run: |
+          pytest -q tests

--- a/app.py
+++ b/app.py
@@ -1147,22 +1147,26 @@ def calculate_options_pnl():
                        [-0.15, -0.1, -0.05, 0, 0.05, 0.1, 0.15]]
         time_slices = [round(t, 3) for t in
                        [time_to_exp,
-                        max(time_to_exp*0.75, 1/365),
-                        max(time_to_exp*0.50, 1/365),
-                        max(time_to_exp*0.25, 1/365),
+                        max(time_to_exp * 0.75, 1 / 365),
+                        max(time_to_exp * 0.50, 1 / 365),
+                        max(time_to_exp * 0.25, 1 / 365),
                         0]]
 
-        scenarios = []
-        for t in time_slices:
-            for Px in price_steps:
+        pnl_data = []
+        for Px in price_steps:
+            time_data = []
+            for t in time_slices:
                 theo = black_scholes(Px, strike, t, 0.02, implied_vol, option_type)
-                pnl  = (theo - premium) * quantity * 100
-                scenarios.append({
-                    "t_years": round(t,3),
-                    "underlying": Px,
-                    "theo_price": round(theo, 2),
-                    "pnl": round(pnl, 2)
+                pnl = (theo - premium) * quantity * 100
+                ret_pct = (pnl / (premium * quantity * 100) * 100) if premium else 0
+                time_data.append({
+                    "pnl": round(pnl, 2),
+                    "return_percent": round(ret_pct, 2)
                 })
+            pnl_data.append({
+                "stock_price": Px,
+                "time_data": time_data
+            })
 
         # Create the analysis object
         analysis = {
@@ -1176,7 +1180,7 @@ def calculate_options_pnl():
                 "center_price": round(current_price, 2),
                 "standard_deviation": round(implied_vol * current_price, 2),
             },
-            "pnl_data": scenarios,
+            "pnl_data": pnl_data,
         }
 
         return jsonify({"success": True, "analysis": analysis})

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,2 @@
+from app import app
+app.app_context().push()

--- a/tests/test_options_pnl.py
+++ b/tests/test_options_pnl.py
@@ -1,0 +1,25 @@
+from datetime import datetime, timedelta
+from app import app
+
+
+def test_options_pnl_structure():
+    client = app.test_client()
+    exp_date = (datetime.now() + timedelta(days=30)).strftime('%Y-%m-%d')
+    payload = {
+        "option_type": "call",
+        "strike": 100,
+        "current_price": 105,
+        "expiration_date": exp_date,
+        "premium": 5,
+        "quantity": 1,
+    }
+    response = client.post("/tools/options-pnl", json=payload)
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data["success"] is True
+    analysis = data["analysis"]
+    time_points = analysis["option_info"]["time_points"]
+    for price_data in analysis["pnl_data"]:
+        assert "stock_price" in price_data
+        assert "time_data" in price_data
+        assert len(price_data["time_data"]) == len(time_points)


### PR DESCRIPTION
## Summary
- create CI workflow running pytest
- restructure `/tools/options-pnl` response to return grouped time series data
- add tests package init pushing Flask app context
- test PnL endpoint structure

## Testing
- `pytest -q tests`

------
https://chatgpt.com/codex/tasks/task_e_684459f9f61c83338c15dad7215ad236