### PR TITLE
Update Tradier API variable name

### DIFF
--- a/app.py
+++ b/app.py
@@ -65,23 +65,23 @@ def load_user(id):
 ai_analyzer = TradingAIAnalyzer()
 
 # Initialize Tradier API configuration
-TRADIER_API_KEY = os.getenv("TRADIER_API_KEY")
+TRADIER_API_TOKEN = os.getenv("TRADIER_API_TOKEN")
 TRADIER_API_BASE_URL = "https://api.tradier.com/v1"  # Production environment
 print(f"Tradier API Base URL: {TRADIER_API_BASE_URL}")
-print(f"Tradier token configured: {'Yes' if TRADIER_API_KEY else 'No'}")
+print(f"Tradier token configured: {'Yes' if TRADIER_API_TOKEN else 'No'}")
 
-if not TRADIER_API_KEY:
-    print("Warning: TRADIER_API_KEY environment variable not set")
+if not TRADIER_API_TOKEN:
+    print("Warning: TRADIER_API_TOKEN environment variable not set")
 
 
 def get_tradier_headers():
     """Get headers for Tradier API requests"""
-    if not TRADIER_API_KEY:
-        print("Tradier API key not configured")
+    if not TRADIER_API_TOKEN:
+        print("Tradier API token not configured")
         return None  # Token not configured
 
     headers = {
-        "Authorization": f"Bearer {TRADIER_API_KEY}",
+        "Authorization": f"Bearer {TRADIER_API_TOKEN}",
         "Accept": "application/json",
     }
     return headers
@@ -89,8 +89,8 @@ def get_tradier_headers():
 
 def get_expiration_dates_tradier(symbol):
     """Return available option expiration dates from Tradier"""
-    if not TRADIER_API_KEY:
-        print("Tradier API key not configured")
+    if not TRADIER_API_TOKEN:
+        print("Tradier API token not configured")
         return None
 
     try:
@@ -125,8 +125,8 @@ def get_expiration_dates_tradier(symbol):
 
 def get_options_chain_tradier(symbol, expiration_date=None):
     """Get options chain data using Tradier API"""
-    if not TRADIER_API_KEY:
-        print("Tradier API key not configured")
+    if not TRADIER_API_TOKEN:
+        print("Tradier API token not configured")
         return None, None, None, None
 
     try:
@@ -224,8 +224,8 @@ def get_options_chain_tradier(symbol, expiration_date=None):
 
 def get_stock_price_tradier(symbol):
     """Get current stock price and company name using Tradier API"""
-    if not TRADIER_API_KEY:
-        print("Tradier API key not configured")
+    if not TRADIER_API_TOKEN:
+        print("Tradier API token not configured")
         return None, None
 
     try:
@@ -271,8 +271,8 @@ def get_stock_price_tradier(symbol):
 
 def get_options_chain(symbol, expiration_date=None):
     """Get options chain data using Tradier API only"""
-    if not TRADIER_API_KEY:
-        print("Tradier API key not configured")
+    if not TRADIER_API_TOKEN:
+        print("Tradier API token not configured")
         return None, None, None
 
     try:
@@ -1398,8 +1398,8 @@ def test_options(symbol):
     # Test Tradier API
     result = {
         "symbol": symbol,
-        "tradier_configured": TRADIER_API_KEY != "your_tradier_token_here"
-        and TRADIER_API_KEY,
+        "tradier_configured": TRADIER_API_TOKEN != "your_tradier_token_here"
+        and TRADIER_API_TOKEN,
         "tradier_result": None,
         "errors": [],
     }

--- a/test_api.py
+++ b/test_api.py
@@ -5,9 +5,9 @@ from dotenv import load_dotenv
 load_dotenv()
 
 def test_tradier_api():
-    api_key = os.getenv('TRADIER_API_KEY')
+    api_token = os.getenv('TRADIER_API_TOKEN')
     headers = {
-        'Authorization': f'Bearer {api_key}',
+        'Authorization': f'Bearer {api_token}',
         'Accept': 'application/json'
     }
     

--- a/test_env.py
+++ b/test_env.py
@@ -6,19 +6,14 @@ load_dotenv()
 print("Environment variables loaded from .env file")
 
 # Check Tradier API variables
-tradier_key = os.getenv('TRADIER_API_KEY')
 tradier_token = os.getenv('TRADIER_API_TOKEN')
 tradier_base_url = os.getenv('TRADIER_API_BASE_URL')
 
 print("\nTradier API Configuration:")
-print(f"TRADIER_API_KEY: {'Set' if tradier_key else 'Not set'}")
 print(f"TRADIER_API_TOKEN: {'Set' if tradier_token else 'Not set'}")
 print(f"TRADIER_API_BASE_URL: {tradier_base_url}")
 
 # Print actual values (masked for security)
-if tradier_key:
-    masked_key = tradier_key[:4] + '*' * (len(tradier_key) - 8) + tradier_key[-4:]
-    print(f"\nMasked TRADIER_API_KEY: {masked_key}")
 if tradier_token:
     masked_token = tradier_token[:4] + '*' * (len(tradier_token) - 8) + tradier_token[-4:]
-    print(f"Masked TRADIER_API_TOKEN: {masked_token}") 
+    print(f"Masked TRADIER_API_TOKEN: {masked_token}")


### PR DESCRIPTION
## Summary
- rename env var TRADIER_API_KEY to TRADIER_API_TOKEN
- adjust app print statements accordingly
- update tests to match the new variable

## Testing
- `pip install -r requirements.txt`
- `pip install scipy`
- `pytest -q` *(fails: requests.exceptions.ProxyError, sqlalchemy.exc.OperationalError)*

------
https://chatgpt.com/codex/tasks/task_e_684459f084a48333a163109a6fa23d94