### PR TITLE
Show current price in PnL header

### DIFF
--- a/templates/pnl_modal.html
+++ b/templates/pnl_modal.html
@@ -12,6 +12,8 @@
                         &nbsp;|&nbsp;
                         <strong>Strike:</strong> $<span id="strikePrice"></span>
                         &nbsp;|&nbsp;
+                        <strong>Current Price:</strong> $<span id="currentPrice"></span>
+                        &nbsp;|&nbsp;
                         <strong>Premium:</strong> $<span id="premium"></span>
                         &nbsp;|&nbsp;
                         <strong>Days to Exp:</strong> <span id="daysToExp"></span>

--- a/templates/tools/options_calculator.html
+++ b/templates/tools/options_calculator.html
@@ -992,6 +992,7 @@ document.addEventListener('DOMContentLoaded', function() {
                 currentPnLData = analysis;
                 document.getElementById('optionType').textContent = analysis.option_info.type.toUpperCase();
                 document.getElementById('strikePrice').textContent = analysis.option_info.strike;
+                document.getElementById('currentPrice').textContent = analysis.option_info.center_price;
                 document.getElementById('premium').textContent = analysis.option_info.premium;
                 document.getElementById('daysToExp').textContent = analysis.option_info.days_to_expiration;
                 updateTable(analysis, showingDollars);


### PR DESCRIPTION
## Summary
- display the option's current price in the P&L modal header
- populate the new field when showing the P&L analysis

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68446c1869988333abe544b0ff5186b0