### PR TITLE
Remove implied volatility input

### DIFF
--- a/templates/add_trade.html
+++ b/templates/add_trade.html
@@ -111,19 +111,6 @@
                                     {% endif %}
                                 </div>
                             </div>
-                            <div class="col-md-3">
-                                <div class="mb-3">
-                                    {{ form.implied_volatility.label(class="form-label") }}
-                                    {{ form.implied_volatility(class="form-control") }}
-                                    {% if form.implied_volatility.errors %}
-                                        <div class="text-danger small">
-                                            {% for error in form.implied_volatility.errors %}
-                                                <div>{{ error }}</div>
-                                            {% endfor %}
-                                        </div>
-                                    {% endif %}
-                                </div>
-                            </div>
                         </div>
                         
                         <!-- Underlying Stock Prices -->


### PR DESCRIPTION
## Summary
- remove Implied Volatility (%) from the options details row on the Add Trade page

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68463620424083339869c869a1122c65