### PR TITLE
Remove redundant premium input from options details

### DIFF
--- a/templates/add_trade.html
+++ b/templates/add_trade.html
@@ -100,19 +100,6 @@
                             </div>
                             <div class="col-md-3">
                                 <div class="mb-3">
-                                    {{ form.premium_paid.label(class="form-label") }}
-                                    {{ form.premium_paid(class="form-control") }}
-                                    {% if form.premium_paid.errors %}
-                                        <div class="text-danger small">
-                                            {% for error in form.premium_paid.errors %}
-                                                <div>{{ error }}</div>
-                                            {% endfor %}
-                                        </div>
-                                    {% endif %}
-                                </div>
-                            </div>
-                            <div class="col-md-3">
-                                <div class="mb-3">
                                     {{ form.implied_volatility.label(class="form-label") }}
                                     {{ form.implied_volatility(class="form-control") }}
                                     {% if form.implied_volatility.errors %}

--- a/templates/view_trade.html
+++ b/templates/view_trade.html
@@ -144,10 +144,6 @@
                                 </td>
                             </tr>
                             <tr>
-                                <td class="text-muted">Premium Paid:</td>
-                                <td>${{ "%.2f"|format(trade.premium_paid) if trade.premium_paid else 'N/A' }}</td>
-                            </tr>
-                            <tr>
                                 <td class="text-muted">Implied Volatility:</td>
                                 <td>{{ "%.1f"|format(trade.implied_volatility) }}% if trade.implied_volatility else 'N/A' }}</td>
                             </tr>


### PR DESCRIPTION
## Summary
- remove `Premium Per Contract` input from Options Details section
- hide Premium Paid row when viewing an options trade

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846397add0c8333b821bd2f58760b7a