### PR TITLE
Fix Add Trade template syntax error

### DIFF
--- a/templates/add_trade.html
+++ b/templates/add_trade.html
@@ -98,15 +98,6 @@
                                     {% endif %}
                                 </div>
                             </div>
-                            <div class="col-md-3">
-                                <div class="mb-3">
-
-                                                <div>{{ error }}</div>
-                                            {% endfor %}
-                                        </div>
-                                    {% endif %}
-                                </div>
-                            </div>
                         </div>
                         
                         <!-- Underlying Stock Prices -->


### PR DESCRIPTION
## Summary
- remove stray `endfor` block from `add_trade.html`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68465a75bc3483339bcabdb15d9b7ce8