### PR TITLE
Set dummy OPENAI_API_KEY for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    env:
+      OPENAI_API_KEY: dummy-key
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python


### PR DESCRIPTION
## Summary
- add OPENAI_API_KEY to CI test job to avoid import errors

## Testing
- `pytest -q tests/smoke.py`

------
https://chatgpt.com/codex/tasks/task_e_6848fa9955848333beab1b2329ccb432