### PR TITLE
Fix blank option coercion in journal form

### DIFF
--- a/forms.py
+++ b/forms.py
@@ -252,7 +252,7 @@ class JournalForm(FlaskForm):
     ], validators=[Optional()])
     
     stress_level = SelectField('Stress Level', choices=[
-        ('', 'Select...'),
+        (0, 'Select...'),
         (1, '1 - Very Relaxed'),
         (2, '2 - Relaxed'),
         (3, '3 - Slightly Tense'),
@@ -266,7 +266,7 @@ class JournalForm(FlaskForm):
     ], validators=[Optional()], coerce=int)
     
     discipline_score = SelectField('Discipline Score', choices=[
-        ('', 'Rate your discipline...'),
+        (0, 'Rate your discipline...'),
         (1, '1 - Very Poor'),
         (2, '2 - Poor'),
         (3, '3 - Below Average'),


### PR DESCRIPTION
## Summary
- avoid int coercion errors for blank choices by using `0` in JournalForm

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848fa9312a4833392efa16fab8e4951