### PR TITLE
Add unique journal constraint

### DIFF
--- a/migrate_journal_unique.py
+++ b/migrate_journal_unique.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python3
+"""Database migration script to enforce unique journal dates per user."""
+
+from app import app
+from models import db
+
+
+def migrate_database():
+    """Add unique constraint on (user_id, journal_date) in trading_journal."""
+    with app.app_context():
+        try:
+            with db.engine.connect() as conn:
+                conn.execute(
+                    db.text(
+                        "CREATE UNIQUE INDEX IF NOT EXISTS uix_user_journal_date ON trading_journal (user_id, journal_date)"
+                    )
+                )
+                conn.commit()
+            print("✅ Added unique constraint on user_id and journal_date")
+        except Exception as e:
+            print(f"⚠️  Could not create constraint: {e}")
+
+        print("\n🎉 Journal constraint migration completed!")
+
+
+if __name__ == "__main__":
+    print("🚀 Starting journal unique constraint migration...")
+    migrate_database()

--- a/models.py
+++ b/models.py
@@ -741,7 +741,11 @@ class TradingJournal(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     user_id = db.Column(db.Integer, db.ForeignKey("user.id"), nullable=False)
 
-    journal_date = db.Column(db.Date, nullable=False, unique=True)
+    journal_date = db.Column(db.Date, nullable=False)
+
+    __table_args__ = (
+        db.UniqueConstraint('user_id', 'journal_date', name='uix_user_journal_date'),
+    )
 
     # Daily reflections
     daily_pnl = db.Column(db.Float)


### PR DESCRIPTION
## Summary
- ensure each user can only have one TradingJournal entry per date
- add migration script to enforce the constraint at the DB level

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6848fa90a3ac833396147c5cc9da8797