### PR TITLE
Fix Get Started button to go to home

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -26,7 +26,7 @@
                             <i class="fas fa-calculator me-2"></i>Options Calculator
                         </a>
                     {% else %}
-                        <a href="{{ url_for('register') }}" class="btn btn-primary btn-lg px-4 me-md-2">
+                        <a href="{{ url_for('dashboard') }}" class="btn btn-primary btn-lg px-4 me-md-2">
                             <i class="fas fa-rocket me-2"></i>Get Started
                         </a>
                         <a href="{{ url_for('login') }}" class="btn btn-outline-secondary btn-lg px-4">


### PR DESCRIPTION
## Summary
- change Get Started button link to go to the dashboard instead of registration

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a3a73cac88333ab80373775e21857