### PR TITLE
Fix analytics for open trades

### DIFF
--- a/models.py
+++ b/models.py
@@ -361,7 +361,7 @@ class Trade(db.Model):
 
     def calculate_pnl(self):
         """Calculate P&L for both open and closed trades"""
-        if self.exit_price:
+        if self.exit_price is not None:
             # Closed trade - use actual exit price
             if self.is_spread_trade():
                 self.calculate_spread_pnl()

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -92,3 +92,67 @@ def test_analytics_route_returns_json_when_trades_exist():
         assert set(["pnl_over_time", "win_loss_pie", "setup_performance"]).issubset(data.keys())
         stats_keys = {"total_trades", "winning_trades", "losing_trades", "win_rate"}
         assert stats_keys.issubset(context["stats"].keys())
+
+
+def test_analytics_handles_zero_exit_price():
+    client = app.test_client()
+    with app.app_context():
+        user = create_user()
+        trade = Trade(
+            user_id=user.id,
+            symbol="MSFT",
+            trade_type="long",
+            entry_date=datetime.utcnow(),
+            entry_price=50,
+            quantity=1,
+            exit_price=0,
+            exit_date=datetime.utcnow(),
+        )
+        trade.calculate_pnl()
+        db.session.add(trade)
+        db.session.commit()
+    login(client, "user", "test")
+    with captured_templates(app) as templates:
+        response = client.get("/analytics")
+        assert response.status_code == 200
+        template, context = templates[0]
+        assert context["stats"]["total_trades"] == 1
+        assert context["stats"]["losing_trades"] == 1
+
+
+def test_analytics_includes_open_trades(monkeypatch):
+    client = app.test_client()
+    with app.app_context():
+        user = create_user()
+        closed_trade = Trade(
+            user_id=user.id,
+            symbol="AAPL",
+            trade_type="long",
+            entry_date=datetime.utcnow(),
+            entry_price=100,
+            quantity=1,
+            exit_price=110,
+            exit_date=datetime.utcnow(),
+        )
+        closed_trade.calculate_pnl()
+
+        open_trade = Trade(
+            user_id=user.id,
+            symbol="TSLA",
+            trade_type="long",
+            entry_date=datetime.utcnow(),
+            entry_price=100,
+            quantity=1,
+        )
+        monkeypatch.setattr(Trade, "get_current_market_price", lambda self: 105)
+        open_trade.calculate_pnl()
+
+        db.session.add_all([closed_trade, open_trade])
+        db.session.commit()
+    login(client, "user", "test")
+    with captured_templates(app) as templates:
+        response = client.get("/analytics")
+        assert response.status_code == 200
+        template, context = templates[0]
+        assert context["stats"]["total_trades"] == 2
+        assert context["stats"]["winning_trades"] == 2


### PR DESCRIPTION
## Summary
- include open trades when calculating analytics
- test analytics with open trade

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6850e02363e883338b36bf4821c37690