### PR TITLE
Fix educational resources links

### DIFF
--- a/templates/tools/index.html
+++ b/templates/tools/index.html
@@ -201,17 +201,17 @@
                     <div class="col-md-4 mb-3">
                         <h6><i class="fas fa-book text-primary me-2"></i>Options Basics</h6>
                         <p class="small text-muted mb-2">Learn the fundamentals of options trading, including calls, puts, and basic strategies.</p>
-                        <a href="#" class="btn btn-sm btn-outline-primary">Read Guide</a>
+                        <a href="https://www.investopedia.com/options-basics-tutorial-4583012" class="btn btn-sm btn-outline-primary" target="_blank" rel="noopener">Read Guide</a>
                     </div>
                     <div class="col-md-4 mb-3">
                         <h6><i class="fas fa-calculator text-warning me-2"></i>Greeks Explained</h6>
                         <p class="small text-muted mb-2">Understand Delta, Gamma, Theta, and Vega and how they affect option pricing.</p>
-                        <a href="#" class="btn btn-sm btn-outline-warning">Learn More</a>
+                        <a href="https://www.investopedia.com/options-greeks-4689745" class="btn btn-sm btn-outline-warning" target="_blank" rel="noopener">Learn More</a>
                     </div>
                     <div class="col-md-4 mb-3">
                         <h6><i class="fas fa-shield-alt text-success me-2"></i>Risk Management</h6>
                         <p class="small text-muted mb-2">Master position sizing, stop losses, and portfolio risk management techniques.</p>
-                        <a href="#" class="btn btn-sm btn-outline-success">Explore</a>
+                        <a href="https://www.investopedia.com/articles/trading/09/risk-management.htm" class="btn btn-sm btn-outline-success" target="_blank" rel="noopener">Explore</a>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- link educational resource buttons to relevant Investopedia articles

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850eb88bc588333abf3f05f0e944453