### PR TITLE
Allow guest journal entries and trade views

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,9 +109,10 @@ ALLOWED_EXTENSIONS=png,jpg,jpeg,gif,pdf
 
 ### Getting Started
 
-You can try the platform without logging in. The options calculator and the "Add Trade"
-and journal pages are fully accessible to guests. However, you must create an
-account or log in if you want to save your trades or get AI-powered analysis.
+You can try the platform without logging in. The options calculator, "Add Trade",
+the trades tab and journal pages are fully accessible to guests. Journal entries
+you create while logged out are stored anonymously. Log in if you want your
+trades or journals saved to your account or to access AI-powered analysis.
 
 1. **Register an Account**
    - Create your trading account with email verification

--- a/migrate_journal_nullable.py
+++ b/migrate_journal_nullable.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+"""Migration to allow NULL user_id in trading_journal."""
+from app import app
+from models import db
+
+
+def migrate_database():
+    """Alter trading_journal.user_id to be nullable."""
+    with app.app_context():
+        try:
+            with db.engine.connect() as conn:
+                conn.execute(db.text(
+                    "ALTER TABLE trading_journal ALTER COLUMN user_id DROP NOT NULL"
+                ))
+                conn.commit()
+            print("✅ user_id column set to nullable in trading_journal")
+        except Exception as e:
+            print(f"⚠️  Could not alter user_id column: {e}")
+
+
+if __name__ == "__main__":
+    print("🚀 Starting trading journal nullable migration...")
+    migrate_database()

--- a/models.py
+++ b/models.py
@@ -739,7 +739,8 @@ class TradingJournal(db.Model):
     """Daily trading journal entries"""
 
     id = db.Column(db.Integer, primary_key=True)
-    user_id = db.Column(db.Integer, db.ForeignKey("user.id"), nullable=False)
+    # user_id is optional so guests can post journals
+    user_id = db.Column(db.Integer, db.ForeignKey("user.id"), nullable=True)
 
     journal_date = db.Column(db.Date, nullable=False)
 

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -161,3 +161,28 @@ def test_analytics_includes_open_trades(monkeypatch):
         assert context["stats"]["total_trades"] == 2
         assert context["stats"]["winning_trades"] == 2
 
+
+def test_trades_page_guest_access():
+    client = app.test_client()
+    response = client.get("/trades")
+    assert response.status_code == 200
+
+
+def test_journal_page_guest_access():
+    client = app.test_client()
+    response = client.get("/journal")
+    assert response.status_code == 200
+
+
+def test_guest_can_post_journal():
+    client = app.test_client()
+    today = date.today().strftime("%Y-%m-%d")
+    response = client.post(
+        "/journal/add",
+        data={"journal_date": today, "daily_pnl": 0},
+    )
+    assert response.status_code == 302
+    with app.app_context():
+        entry = TradingJournal.query.filter_by(journal_date=date.today()).first()
+        assert entry is not None
+


### PR DESCRIPTION
## Summary
- let guests view `/trades` and `/journal`
- allow posting journals without authentication
- make journal `user_id` optional and add migration script
- update README on guest features
- add tests for guest access

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685784ff90008333b83562aac956cca3